### PR TITLE
add a dedicated venue page

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -13,6 +13,7 @@ The elm-conf call for proposals (CFP) opens April 9th and runs through May 13th.
 elm-conf is a conference for the Elm programming language community, currently in its third year.
 If you're interested in Elm, functional programming, or frontend development in general, please join us!
 
+<!-- TODO: remove these two sections  in favor of the venue page once speakers are announced. -->
 ## Conference Venue and General Schedule
 
 elm-conf will be taking place on September 26 at the historic Peabody Opera house in St. Louis, MO.

--- a/content/venue.md
+++ b/content/venue.md
@@ -7,7 +7,7 @@ We are returning as a Strange Loop pre-conference event, and attendees are welco
 We encourage you to attend Strange Loop as well as elm-conf.
 If you like one you'll probably like the other!
 
-## Flying In
+## Flights to St. Louis
 
 [St. Louis Lambert International Airport (STL)](https://www.flystl.com/flights-and-airlines/airlines) is the closest airport to the venue.
 

--- a/content/venue.md
+++ b/content/venue.md
@@ -14,3 +14,11 @@ If you like one you'll probably like the other!
 Lambert-St. Louis International Airport (STL) is the closest airport to the venue, and you can take a metrolink train ($3, Union Station stop), Lyft (~$35), or taxi (~$40) downtown.
 
 Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See Strange Loops Hotel Page for more details.
+
+## Dress Code
+
+elm-conf not specify a formal dress code.
+Wear whatever you're comfortable with as long as it does not violate the [code of conduct](https://thestrangeloop.com/policies.html).
+
+If you're a first-time conference-goer and nervous about what to wear, [business casual](https://en.wikipedia.org/wiki/Business_casual) is a safe bet.
+In past years, people have dressed in a wide range from [casual](https://en.wikipedia.org/wiki/Casual) to business casual.

--- a/content/venue.md
+++ b/content/venue.md
@@ -9,9 +9,14 @@ If you like one you'll probably like the other!
 
 ## Getting (and Staying) There
 
-<!-- TODO: make this information into a table -->
+Lambert-St. Louis International Airport (STL) is the closest airport to the venue.
+Here's how you can get downtown:
 
-Lambert-St. Louis International Airport (STL) is the closest airport to the venue, and you can take a metrolink train ($3, Union Station stop), Lyft (~$35), or taxi (~$40) downtown.
+| How? | Cost | Extra Information |
+|-|-|-|
+| Metrolink Train | $3 | Get off at the Union Station Stop |
+| Lyft | ~$35 | |
+| Taxi | ~$40 | |
 
 Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See Strange Loops Hotel Page for more details.
 

--- a/content/venue.md
+++ b/content/venue.md
@@ -7,15 +7,20 @@ We are returning as a Strange Loop pre-conference event, and attendees are welco
 We encourage you to attend Strange Loop as well as elm-conf.
 If you like one you'll probably like the other!
 
-## Getting (and Staying) There
+## Flying In
 
-Lambert-St. Louis International Airport (STL) is the closest airport to the venue.
-Here's how you can get downtown:
+[St. Louis Lambert International Airport (STL)](https://www.flystl.com/flights-and-airlines/airlines) is the closest airport to the venue.
+
+For domestic travel, Southwest Airlines has nonstop flights to St. Louis from many cities in the United States.
+
+For international travel, most carriers will go through immigration and customs at Chicago O'Hare with a connection to St. Louis. WOW air recently opened connecting flights through Reykjavik, if that's more convenient for you.
+
+From the airport, here are some ways you can to the hotels and conference venue:
 
 | How? | Cost | Extra Information |
 |:-|-:|:-|
 | Metrolink Train | $3 | Get off at the Union Station Stop |
-| Lyft | ~$35 | |
+| Lyft | $28-37 | Get updated estimates at [Lyft's Fare Estimator](https://www.lyft.com/fare-estimate) |
 | Taxi | ~$40 | |
 
 Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See [Strange Loops Hotel Page](https://thestrangeloop.com/register.html) for more details.

--- a/content/venue.md
+++ b/content/venue.md
@@ -26,7 +26,7 @@ From the airport, here are some ways you can to the hotels and conference venue:
 
 ## Staying in St. Louis
 
-Hotel stays can be booked in the Strange Loo at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.)
+Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.)
 See [their hotel page](https://thestrangeloop.com/register.html) for more details.
 Strange Loop will be providing shuttle service from Union Station and Hilton Ballpark to events such as the conference party.
 

--- a/content/venue.md
+++ b/content/venue.md
@@ -9,6 +9,8 @@ If you like one you'll probably like the other!
 
 ## Getting (and Staying) There
 
+<!-- TODO: make this information into a table -->
+
 Lambert-St. Louis International Airport (STL) is the closest airport to the venue, and you can take a metrolink train ($3, Union Station stop), Lyft (~$35), or taxi (~$40) downtown.
 
 Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See Strange Loops Hotel Page for more details.

--- a/content/venue.md
+++ b/content/venue.md
@@ -1,0 +1,14 @@
+---
+title: Venue
+---
+
+elm-conf will be taking place on September 26 at the historic Peabody Opera house in St. Louis, MO.
+We are returning as a Strange Loop pre-conference event, and attendees are welcome at the Strange Loop party at City Museum during the evening of the 26th.
+We encourage you to attend Strange Loop as well as elm-conf.
+If you like one you'll probably like the other!
+
+## Getting (and Staying) There
+
+Lambert-St. Louis International Airport (STL) is the closest airport to the venue, and you can take a metrolink train ($3, Union Station stop), Lyft (~$35), or taxi (~$40) downtown.
+
+Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See Strange Loops Hotel Page for more details.

--- a/content/venue.md
+++ b/content/venue.md
@@ -36,3 +36,7 @@ Wear whatever you're comfortable with as long as it does not violate the [code o
 
 If you're a first-time conference-goer and nervous about what to wear, [business casual](https://en.wikipedia.org/wiki/Business_casual) is a safe bet.
 In past years, people have dressed in a wide range from [casual](https://en.wikipedia.org/wiki/Casual) to business casual.
+
+## Accessibility
+
+TODO

--- a/content/venue.md
+++ b/content/venue.md
@@ -18,7 +18,7 @@ Here's how you can get downtown:
 | Lyft | ~$35 | |
 | Taxi | ~$40 | |
 
-Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See Strange Loops Hotel Page for more details.
+Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See [Strange Loops Hotel Page](https://thestrangeloop.com/register.html) for more details.
 
 ## Dress Code
 

--- a/content/venue.md
+++ b/content/venue.md
@@ -23,7 +23,11 @@ From the airport, here are some ways you can to the hotels and conference venue:
 | Lyft | $28-37 | Get updated estimates at [Lyft's Fare Estimator](https://www.lyft.com/fare-estimate) |
 | Taxi | ~$40 | |
 
-Hotel stays can be booked in the Strange Loop blocks at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.) See [Strange Loops Hotel Page](https://thestrangeloop.com/register.html) for more details.
+## Staying in St. Louis
+
+Hotel stays can be booked in the Strange Loo at Union Station (~10min walk) or the Ballpark Hilton (~15 minute walk.)
+See [their hotel page](https://thestrangeloop.com/register.html) for more details.
+Strange Loop will be providing shuttle service from Union Station and Hilton Ballpark to events such as the conference party.
 
 ## Dress Code
 

--- a/content/venue.md
+++ b/content/venue.md
@@ -13,7 +13,7 @@ Lambert-St. Louis International Airport (STL) is the closest airport to the venu
 Here's how you can get downtown:
 
 | How? | Cost | Extra Information |
-|-|-|-|
+|:-|-:|:-|
 | Metrolink Train | $3 | Get off at the Union Station Stop |
 | Lyft | ~$35 | |
 | Taxi | ~$40 | |

--- a/content/venue.md
+++ b/content/venue.md
@@ -13,7 +13,8 @@ If you like one you'll probably like the other!
 
 For domestic travel, Southwest Airlines has nonstop flights to St. Louis from many cities in the United States.
 
-For international travel, most carriers will go through immigration and customs at Chicago O'Hare with a connection to St. Louis. WOW air recently opened connecting flights through Reykjavik, if that's more convenient for you.
+For international travel, most carriers will go through immigration and customs at Chicago O'Hare with a connection to St. Louis.
+WOW air recently opened connecting flights through Reykjavik, if that's more convenient for you.
 
 From the airport, here are some ways you can to the hotels and conference venue:
 

--- a/src/Page/Content.elm
+++ b/src/Page/Content.elm
@@ -25,6 +25,12 @@ type Content
     | Text String
     | Emphasized EmphasisAmount (List Content)
     | Code (List Content)
+    | Table (List Content)
+    | TableRow (List Content)
+    | TableHead (List Content)
+    | TableHeadCell (List Content)
+    | TableBody (List Content)
+    | TableCell (List Content)
 
 
 type Level
@@ -116,6 +122,24 @@ element tag =
 
         "code" ->
             map Code children
+
+        "table" ->
+            map Table children
+
+        "thead" ->
+            map TableHead children
+
+        "tbody" ->
+            map TableBody children
+
+        "tr" ->
+            map TableRow children
+
+        "td" ->
+            map TableCell children
+
+        "th" ->
+            map TableHeadCell children
 
         _ ->
             fail ("The '" ++ tag ++ "' tag is not allowed!")

--- a/src/Page/Content/View.elm
+++ b/src/Page/Content/View.elm
@@ -70,7 +70,7 @@ content node =
             Html.table [ SElements.table ] (List.map content children)
 
         TableHead children ->
-            Html.thead [] (List.map content children)
+            Html.thead [ SElements.tableHead ] (List.map content children)
 
         TableBody children ->
             Html.tbody [] (List.map content children)

--- a/src/Page/Content/View.elm
+++ b/src/Page/Content/View.elm
@@ -78,8 +78,8 @@ content node =
         TableRow children ->
             Html.tr [] (List.map content children)
 
-        TableHeadCell children ->
-            Html.th [ Text.strong ] (List.map content children)
+        TableHeadCell alignment children ->
+            Html.th [ Text.strong, Text.align alignment ] (List.map content children)
 
-        TableCell children ->
-            Html.td [] (List.map content children)
+        TableCell alignment children ->
+            Html.td [ Text.align alignment ] (List.map content children)

--- a/src/Page/Content/View.elm
+++ b/src/Page/Content/View.elm
@@ -67,7 +67,7 @@ content node =
             Html.code [ Text.code ] (List.map content children)
 
         Table children ->
-            Html.table [ SElements.fillWidth ] (List.map content children)
+            Html.table [ SElements.table ] (List.map content children)
 
         TableHead children ->
             Html.thead [] (List.map content children)
@@ -79,7 +79,16 @@ content node =
             Html.tr [] (List.map content children)
 
         TableHeadCell alignment children ->
-            Html.th [ Text.strong, Text.align alignment ] (List.map content children)
+            Html.th
+                [ SElements.tableCell
+                , Text.strong
+                , Text.align alignment
+                ]
+                (List.map content children)
 
         TableCell alignment children ->
-            Html.td [ Text.align alignment ] (List.map content children)
+            Html.td
+                [ SElements.tableCell
+                , Text.align alignment
+                ]
+                (List.map content children)

--- a/src/Page/Content/View.elm
+++ b/src/Page/Content/View.elm
@@ -11,6 +11,7 @@ import Page.Content
         , Root(Root)
         )
 import Route
+import Styles.Elements as SElements
 import Styles.Text as Text
 import View.Elements as Elements
 
@@ -64,3 +65,21 @@ content node =
 
         Code children ->
             Html.code [ Text.code ] (List.map content children)
+
+        Table children ->
+            Html.table [ SElements.fillWidth ] (List.map content children)
+
+        TableHead children ->
+            Html.thead [] (List.map content children)
+
+        TableBody children ->
+            Html.tbody [] (List.map content children)
+
+        TableRow children ->
+            Html.tr [] (List.map content children)
+
+        TableHeadCell children ->
+            Html.th [ Text.strong ] (List.map content children)
+
+        TableCell children ->
+            Html.td [] (List.map content children)

--- a/src/Styles/Elements.elm
+++ b/src/Styles/Elements.elm
@@ -3,6 +3,7 @@ module Styles.Elements
         ( ghostButton
         , table
         , tableCell
+        , tableHead
         )
 
 import Css exposing (..)
@@ -32,10 +33,18 @@ table =
         ]
 
 
+tableHead : Attribute msg
+tableHead =
+    css
+        [ color Colors.peach
+        , borderBottom3 (px 1) solid Colors.peach
+        ]
+
+
 tableCell : Attribute msg
 tableCell =
     css
-        [ padding (Text.scale 0)
+        [ padding (px 10)
         , fontFeatureSettingsList
             [ featureTag "tnum"
             , featureTag "zero"

--- a/src/Styles/Elements.elm
+++ b/src/Styles/Elements.elm
@@ -1,4 +1,4 @@
-module Styles.Elements exposing (ghostButton)
+module Styles.Elements exposing (fillWidth, ghostButton)
 
 import Css exposing (..)
 import Html.Styled exposing (Attribute)
@@ -16,3 +16,8 @@ ghostButton =
         , hover [ textDecoration none ]
         , backgroundColor Colors.ghostlyWhite
         ]
+
+
+fillWidth : Attribute msg
+fillWidth =
+    css [ width (pct 100) ]

--- a/src/Styles/Elements.elm
+++ b/src/Styles/Elements.elm
@@ -1,9 +1,15 @@
-module Styles.Elements exposing (fillWidth, ghostButton)
+module Styles.Elements
+    exposing
+        ( ghostButton
+        , table
+        , tableCell
+        )
 
 import Css exposing (..)
 import Html.Styled exposing (Attribute)
 import Html.Styled.Attributes exposing (css)
 import Styles.Colors as Colors
+import Styles.Text as Text
 
 
 ghostButton : Attribute msg
@@ -18,6 +24,20 @@ ghostButton =
         ]
 
 
-fillWidth : Attribute msg
-fillWidth =
-    css [ width (pct 100) ]
+table : Attribute msg
+table =
+    css
+        [ marginBottom (Text.scale 1)
+        , width (pct 100)
+        ]
+
+
+tableCell : Attribute msg
+tableCell =
+    css
+        [ padding (Text.scale 0)
+        , fontFeatureSettingsList
+            [ featureTag "tnum"
+            , featureTag "zero"
+            ]
+        ]

--- a/src/Styles/Text.elm
+++ b/src/Styles/Text.elm
@@ -3,6 +3,7 @@ module Styles.Text
         ( a
         , aReversed
         , aReversedInline
+        , align
         , body
         , code
         , em
@@ -35,6 +36,7 @@ import Css exposing (..)
 import Css.Foreign as Foreign
 import Html.Styled exposing (Attribute, Html)
 import Html.Styled.Attributes exposing (css)
+import Page.Content exposing (Alignment(..))
 import Styles.Colors as Colors
 
 
@@ -227,3 +229,20 @@ code =
         [ fontFamily monospace
         , fontSize (Css.rem 0.9)
         ]
+
+
+align : Alignment -> Attribute msg
+align alignment =
+    css <|
+        case alignment of
+            Left ->
+                [ textAlign left ]
+
+            Center ->
+                [ textAlign center ]
+
+            Right ->
+                [ textAlign right ]
+
+            Unset ->
+                []


### PR DESCRIPTION
when we announce speakers, we'll want to have that info front and center instead of general conference information that was useful during the CFP period. We'll also need to provide more venue information then.